### PR TITLE
fix naming errors and one type error, shebang +x

### DIFF
--- a/game/app_states/game_state.py
+++ b/game/app_states/game_state.py
@@ -3,7 +3,7 @@ from collections import deque
 import pygame
 import pygame_gui
 
-from pygame_gui.core import UIWindow
+from pygame_gui.elements import UIWindow
 from pygame_gui.elements import UILabel
 from pygame_gui.elements import UIButton
 
@@ -33,7 +33,7 @@ class TurretCosts:
 class HUDPanel(UIWindow):
     def __init__(self, rect: pygame.Rect, manager: 'pygame_gui.ui_manager.UIManager',
                  player_resources: PlayerResources, turret_costs: TurretCosts):
-        super().__init__(rect, manager, ['hud_panel'])
+        super().__init__(rect, manager, 'hud_panel')
         self.player_resources = player_resources
         self.turret_costs = turret_costs
 

--- a/game/app_states/select_level.py
+++ b/game/app_states/select_level.py
@@ -57,7 +57,7 @@ class SelectLevelMenu(BaseAppState):
             self.level_group_y_start += 25
             
         if len(self.level_button_group) > 0:
-            self.ui_manager.select_focus_element(self.level_button_group[0])
+            self.ui_manager.set_focus_element(self.level_button_group[0])
 
     def end(self):
         self.title_label.kill()
@@ -99,7 +99,7 @@ class SelectLevelMenu(BaseAppState):
                         self.trigger_transition()
 
                     if event.ui_object_id == "#choose_level_button":
-                        self.ui_manager.select_focus_element(event.ui_element)
+                        self.ui_manager.set_focus_element(event.ui_element)
                         for level_data in self.all_level_paths:
                             if level_data.display_name == event.ui_element.text:
                                 self.selected_level_path = level_data.path

--- a/tower_defence.py
+++ b/tower_defence.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import os
 
 import pygame


### PR DESCRIPTION
Made some small fixes that were most likely needed as a result of new updates in pygame_gui with namespaces and such. 
Made tower_defence.py executable with a shebang going to /usr/bin/env python3 for Unix-like systems.
Fixed a TypeError that resulted from putting a string into a one element list. 